### PR TITLE
exclude setup/teardown from test counts

### DIFF
--- a/pytest_notifier/__init__.py
+++ b/pytest_notifier/__init__.py
@@ -36,7 +36,8 @@ def pytest_terminal_summary(terminalreporter):
     tr = terminalreporter
     duration = time() - tr._sessionstarttime
     keys = ('passed', 'failed', 'error', 'deselected')
-    counts = {k: len(tr.stats.get(k, [])) for k in keys}
+    counts = {k: len(list(filter(lambda r: r.when == 'call', tr.stats.get(k, [])))) for k in keys}
+
     if sum(counts.values()) == 0:
         msg = 'No tests ran'
     elif counts['passed'] and not (counts['failed'] or counts['error']):

--- a/pytest_notifier/__init__.py
+++ b/pytest_notifier/__init__.py
@@ -36,7 +36,10 @@ def pytest_terminal_summary(terminalreporter):
     tr = terminalreporter
     duration = time() - tr._sessionstarttime
     keys = ('passed', 'failed', 'error', 'deselected')
-    counts = {k: len(list(filter(lambda r: r.when == 'call', tr.stats.get(k, [])))) for k in keys}
+    counts = {
+        k: len(list(filter(lambda r: getattr(r, 'when', '') == 'call', tr.stats.get(k, []))))
+        for k in keys
+    }
 
     if sum(counts.values()) == 0:
         msg = 'No tests ran'


### PR DESCRIPTION
I noticed the counts displayed were triple my actual test counts, due to counting setup/teardown calls.

Example fix.
