### PR TITLE
Handle interrupted test runs

### DIFF
--- a/pytest_notifier/__init__.py
+++ b/pytest_notifier/__init__.py
@@ -1,6 +1,9 @@
 """pytest-notifier - A pytest plugin to notify test result"""
 from time import time
 
+import pytest
+from _pytest.main import EXIT_INTERRUPTED
+
 from .notifier import notify
 
 
@@ -33,6 +36,12 @@ def pytest_addoption(parser):
         default='py.test',
         help='Notifier title when tests fail.',
     )
+    group.addoption(
+        '--notifier-oninterrupt-title',
+        dest='notifier_oninterrupt_title',
+        default='py.test - interrupted',
+        help='Notifier title when tests are interrupted (e.g. Ctrl-C).',
+    )
 
 
 def get_msg_part(count, group):
@@ -47,28 +56,44 @@ def get_msg_part(count, group):
     return '{} {}'.format(count, suffix)
 
 
-def pytest_terminal_summary(terminalreporter):
-    if not terminalreporter.config.option.notifier:
-        return
+class Notifier:
+    @pytest.hookimpl(trylast=True)
+    def pytest_sessionfinish(self, session, exitstatus):
+        self.exitstatus = exitstatus
 
-    tr = terminalreporter
-    duration = time() - tr._sessionstarttime
-    keys = ('passed', 'failed', 'error', 'deselected')
-    counts = {
-        k: len(list(filter(lambda r: getattr(r, 'when', '') == 'call', tr.stats.get(k, []))))
-        for k in keys
-    }
+    @pytest.hookimpl(trylast=True)
+    def pytest_terminal_summary(self, terminalreporter):
+        if not terminalreporter.config.option.notifier:
+            return
 
-    if sum(counts.values()) == 0:
-        title = terminalreporter.config.option.notifier_onzero_title
-        msg = 'No tests ran'
-    elif counts['passed'] and not (counts['failed'] or counts['error']):
-        title = terminalreporter.config.option.notifier_onpass_title
-        msg = 'Success - {passed} Passed'.format(**counts)
-    else:
-        title = terminalreporter.config.option.notifier_onfail_title
-        msg = ' '.join(filter(None, (
-            get_msg_part(count=counts[k], group=k) for k in keys)))
+        tr = terminalreporter
+        duration = time() - tr._sessionstarttime
+        keys = ('passed', 'failed', 'error', 'deselected')
+        counts = {
+            k: len(list(filter(lambda r: getattr(r, 'when', '') == 'call', tr.stats.get(k, []))))
+            for k in keys
+        }
 
-    msg += ' in {:.2f}s'.format(duration)
-    notify(title, msg)
+        if self.exitstatus == EXIT_INTERRUPTED:
+            title = terminalreporter.config.option.notifier_oninterrupt_title
+            # TODO: same as with last "else", refactor?
+            msg = ' '.join(filter(None, (
+                get_msg_part(count=counts[k], group=k) for k in keys)))
+        elif sum(counts.values()) == 0:
+            title = terminalreporter.config.option.notifier_onzero_title
+            msg = 'No tests ran'
+        elif counts['passed'] and not (counts['failed'] or counts['error']):
+            title = terminalreporter.config.option.notifier_onpass_title
+            msg = 'Success - {passed} Passed'.format(**counts)
+        else:
+            title = terminalreporter.config.option.notifier_onfail_title
+            msg = ' '.join(filter(None, (
+                get_msg_part(count=counts[k], group=k) for k in keys)))
+
+        msg += ' in {:.2f}s'.format(duration)
+        notify(title, msg)
+
+
+def pytest_configure(config):
+    notifier = Notifier()
+    config.pluginmanager.register(notifier, '_notifier')


### PR DESCRIPTION
This uses a instance to store the exitstatus from
`pytest_sessionfinish`, although that could probably just also be done on the
module?!

With `exitstatus` as an argument to the `pytest_terminal_summary` hook
it would be easier (https://github.com/pytest-dev/pytest/pull/1809).
