### PR TITLE
Don't send notifications for worker-processes when run with pytest-xdist

### DIFF
--- a/pytest_notifier/__init__.py
+++ b/pytest_notifier/__init__.py
@@ -28,6 +28,12 @@ def pytest_addoption(parser):
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus):
+
+    # If run together with pytest-xdist
+    # We don't want to send notifications from workers
+    if os.getenv('PYTEST_XDIST_WORKER'):
+        return
+
     if terminalreporter.config.option.notifier_off:
         return
 


### PR DESCRIPTION
Fix: #10 

When being run together with `pytest-xdist` a notification per worker and a notification for the whole test-suite is generated.
This can be tested on this repo by installing `pytest-xdist` and running pytest with the `-n 2` option (2 workers). This generates 3 notifications:
![image](https://user-images.githubusercontent.com/4342153/80112399-5b76a900-8581-11ea-99cc-a8d88f99ff91.png)

With the changes a single notification is created (the one with 2 tests passed).

By checking for the environment variable set in the worker processes by `pytest-xdist` we can exit early and not create the notification.